### PR TITLE
Use tsup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,7 +74,7 @@
             "error",
             {
                 "case": "pascalCase",
-                "ignore": ["GraphQL", "\\.test\\.ts$"]
+                "ignore": ["GraphQL", "\\.config\\.ts$", "\\.test\\.ts$"]
             }
         ],
         "unicorn/custom-error-definition": "error",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
     "name": "@dreamit/graphql-server-base",
     "version": "2.3.0",
     "description": "Base package for @dreamit/graphql-server",
-    "main": "build/index.js",
-    "types": "build/index.d.ts",
     "scripts": {
-        "build": "tsc",
+        "build": "tsup-node",
         "check": "tsc --noEmit --pretty",
         "checkformat": "prettier --check .",
         "format": "prettier --cache --write .",
@@ -13,6 +11,19 @@
         "lintfix": "eslint --fix src/*.ts src/**/*.ts",
         "prepack": "npm run build",
         "test": "echo 'Not defined in this project'"
+    },
+    "type": "module",
+    "main": "build/index.cjs",
+    "module": "build/index.js",
+    "types": "build/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./build/index.d.ts",
+            "import": "./build/index.js",
+            "require": "./build/index.cjs",
+            "default": "./build/index.js"
+        },
+        "./package.json": "./package.json"
     },
     "repository": {
         "type": "git",
@@ -40,6 +51,7 @@
         "eslint-plugin-unicorn": "50.0.1",
         "prettier": "3.2.4",
         "ts-jest": "29.1.1",
+        "tsup": "8.0.1",
         "typescript": "5.3.3"
     },
     "peerDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "ESNext",
         "esModuleInterop": true,
-        "target": "es5",
-        "moduleResolution": "node",
+        "target": "ES2022",
+        "moduleResolution": "Bundler",
         "sourceMap": true,
         "outDir": "build",
-        "lib": ["es2017", "es7", "es6", "dom"],
+        "lib": ["ES2022", "DOM"],
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "declaration": true,
@@ -16,6 +16,6 @@
             "~/*": ["./*"],
         },
     },
-    "include": ["jest.config.js", "src/**/*", "tests/**/*"],
+    "include": ["jest.config.js", "tsup.config.ts", "src/**/*", "tests/**/*"],
     "exclude": ["node_modules"],
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    outDir: 'build',
+    clean: true,
+    target: ['es2022', 'node18'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: false,
+    sourcemap: true,
+    splitting: true,
+})


### PR DESCRIPTION
closes #73 

@sgohlke please explore this PR a bit as you like and inspect the `build` folder.

This PR not only introduces tsup, but also serve esm + cjs, so your customers that use the package can profit from esm if the want/need.

Feel free to ask any questions if you have some. Also don't be shy to reject this PR if tsup is not something that you want. (would be nice if you could provide a reason if so 🙂)