### PR TITLE
Major v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,5 @@
     },
     "overrides": {
         "esbuild": "0.25.0"
-    },
-    "dependencies": {
-        "@dreamit/graphql-server-base": "file:dreamit-graphql-server-base-3.0.0.tgz"
     }
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     },
     "overrides": {
         "esbuild": "0.25.0"
+    },
+    "dependencies": {
+        "@dreamit/graphql-server-base": "file:dreamit-graphql-server-base-3.0.0.tgz"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dreamit/graphql-server-base",
-    "version": "2.7.0",
+    "version": "3.0.0",
     "description": "Base package for @dreamit/graphql-server",
     "scripts": {
         "build": "tsup-node",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-internal-modules */
-export { AggregateError, isAggregateError } from './error/AggregateError'
+export { isAggregateError } from './error/AggregateError'
+export type { AggregateError } from './error/AggregateError'
 export {
     FETCH_ERROR,
     GRAPHQL_ERROR,
@@ -11,21 +12,21 @@ export {
     SYNTAX_ERROR,
     VALIDATION_ERROR,
 } from './error/ErrorNameConstants'
-export { GraphQLErrorWithInfo } from './error/GraphQLErrorWithInfo'
+export type { GraphQLErrorWithInfo } from './error/GraphQLErrorWithInfo'
 
-export { LogEntry } from './logger/LogEntry'
-export { LogEntryInput } from './logger/LogEntryInput'
-export { Logger } from './logger/Logger'
-export { LogLevel } from './logger/LogLevel'
+export type { LogEntry } from './logger/LogEntry'
+export type { LogEntryInput } from './logger/LogEntryInput'
+export type { Logger } from './logger/Logger'
+export type { LogLevel } from './logger/LogLevel'
 
-export { MetricsClient } from './metrics/MetricsClient'
+export type { MetricsClient } from './metrics/MetricsClient'
 
-export { ContentType } from './request/ContentType'
-export { GraphQLRequestInfo } from './request/GraphQLRequestInfo'
-export { GraphQLServerRequest } from './request/GraphQLServerRequest'
+export type { ContentType } from './request/ContentType'
+export type { GraphQLRequestInfo } from './request/GraphQLRequestInfo'
+export type { GraphQLServerRequest } from './request/GraphQLServerRequest'
 export { isGraphQLServerRequest } from './request/IsGraphQLServerRequest'
 
-export { GraphQLExecutionResult } from './response/GraphQLExecutionResult'
-export { GraphQLServerResponse } from './response/GraphQLServerResponse'
-export { ResponseParameters } from './response/ResponseParameters'
-export { StandardSchemaV1 } from './validation/StandardSchemaV1'
+export type { GraphQLExecutionResult } from './response/GraphQLExecutionResult'
+export type { GraphQLServerResponse } from './response/GraphQLServerResponse'
+export type { ResponseParameters } from './response/ResponseParameters'
+export type { StandardSchemaV1 } from './validation/StandardSchemaV1'

--- a/src/logger/LogEntry.ts
+++ b/src/logger/LogEntry.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from './LogLevel'
+import type { LogLevel } from './LogLevel'
 
 export interface LogEntry {
     logger: string

--- a/src/logger/LogEntryInput.ts
+++ b/src/logger/LogEntryInput.ts
@@ -1,5 +1,5 @@
-import { DateFunction } from '@dreamit/funpara'
-import { LogLevel } from './LogLevel'
+import type { DateFunction } from '@dreamit/funpara'
+import type { LogLevel } from './LogLevel'
 
 export interface LogEntryInput {
     context: unknown

--- a/src/logger/LogEntryInput.ts
+++ b/src/logger/LogEntryInput.ts
@@ -2,7 +2,7 @@ import type { DateFunction } from '@dreamit/funpara'
 import type { LogLevel } from './LogLevel'
 
 export interface LogEntryInput {
-    context: unknown
+    context: Record<string, unknown>
     customErrorName?: string
     dateFunction?: DateFunction
     error?: Error

--- a/src/logger/LogLevel.ts
+++ b/src/logger/LogLevel.ts
@@ -1,6 +1,1 @@
-export enum LogLevel {
-    debug = 'DEBUG',
-    error = 'ERROR',
-    info = 'INFO',
-    warn = 'WARN',
-}
+export type LogLevel = 'DEBUG' | 'ERROR' | 'INFO' | 'WARN'

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -1,4 +1,4 @@
-import { DateFunction } from '@dreamit/funpara'
+import type { DateFunction } from '@dreamit/funpara'
 
 export interface Logger {
     readonly loggerName: string

--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -7,24 +7,24 @@ export interface Logger {
 
     debug(
         logMessage: string,
-        context?: unknown,
+        context: Record<string, unknown>,
         dateFunction?: DateFunction,
     ): void
     error(
         logMessage: string,
+        context: Record<string, unknown>,
         error: Error,
         customErrorName?: string,
-        context?: unknown,
         dateFunction?: DateFunction,
     ): void
     info(
         logMessage: string,
-        context?: unknown,
+        context: Record<string, unknown>,
         dateFunction?: DateFunction,
     ): void
     warn(
         logMessage: string,
-        context?: unknown,
+        context: Record<string, unknown>,
         dateFunction?: DateFunction,
     ): void
 }

--- a/src/metrics/MetricsClient.ts
+++ b/src/metrics/MetricsClient.ts
@@ -13,16 +13,16 @@ export interface MetricsClient {
 
     /**
      * Increases the number of requests (by 1)
-     * @param {unknown} context - The request context
+     * @param {Record<string, unknown>} context - The request context
      */
-    increaseRequestThroughput(context?: unknown): void
+    increaseRequestThroughput(context: Record<string, unknown>): void
 
     /**
      * Increases the error counter (by 1)
      * @param {string} label - A label to specify what kind error occurred
-     * @param {unknown} context - The request context
+     * @param {Record<string, unknown>} context - The request context
      */
-    increaseErrors(label: string, context?: unknown): void
+    increaseErrors(label: string, context: Record<string, unknown>): void
     // Gets the Content-Type of the metrics for use in the response headers.
     getMetricsContentType(): string
     // Gets the metrics for use in the response body.

--- a/src/request/ContentType.ts
+++ b/src/request/ContentType.ts
@@ -1,6 +1,5 @@
-export enum ContentType {
-    graphql = 'application/graphql',
-    json = 'application/json',
-    unknown = '',
-    urlencoded = 'application/x-www-form-urlencoded',
-}
+export type ContentType =
+    | ''
+    | 'application/graphql'
+    | 'application/json'
+    | 'application/x-www-form-urlencoded'

--- a/src/request/GraphQLRequestInfo.ts
+++ b/src/request/GraphQLRequestInfo.ts
@@ -1,4 +1,4 @@
-import { GraphQLErrorWithInfo } from '../error/GraphQLErrorWithInfo'
+import type { GraphQLErrorWithInfo } from '../error/GraphQLErrorWithInfo'
 
 export interface GraphQLRequestInfo {
     query?: string

--- a/src/request/GraphQLServerRequest.ts
+++ b/src/request/GraphQLServerRequest.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders } from 'node:http'
+import type { IncomingHttpHeaders } from 'node:http'
 
 /**
  * Interface for incoming server requests.

--- a/src/request/GraphQLServerRequest.ts
+++ b/src/request/GraphQLServerRequest.ts
@@ -8,6 +8,8 @@ import type { IncomingHttpHeaders } from 'node:http'
 export interface GraphQLServerRequest {
     headers: IncomingHttpHeaders
     url?: string
-    body?: unknown
     method?: string
+    // Either body or text should be provided in order to get the request body.
+    body?: unknown
+    text?: ()=> Promise<string>
 }

--- a/src/request/GraphQLServerRequest.ts
+++ b/src/request/GraphQLServerRequest.ts
@@ -11,5 +11,5 @@ export interface GraphQLServerRequest {
     method?: string
     // Either body or text should be provided in order to get the request body.
     body?: unknown
-    text?: ()=> Promise<string>
+    text?: () => Promise<string>
 }

--- a/src/request/IsGraphQLServerRequest.ts
+++ b/src/request/IsGraphQLServerRequest.ts
@@ -1,5 +1,5 @@
-import { GraphQLRequestInfo } from './GraphQLRequestInfo'
-import { GraphQLServerRequest } from './GraphQLServerRequest'
+import type { GraphQLRequestInfo } from './GraphQLRequestInfo'
+import type { GraphQLServerRequest } from './GraphQLServerRequest'
 
 export function isGraphQLServerRequest(
     request: GraphQLServerRequest | GraphQLRequestInfo,

--- a/src/response/GraphQLExecutionResult.ts
+++ b/src/response/GraphQLExecutionResult.ts
@@ -1,5 +1,5 @@
-import { ExecutionResult } from 'graphql'
-import { GraphQLRequestInfo } from '../request/GraphQLRequestInfo'
+import type { ExecutionResult } from 'graphql'
+import type { GraphQLRequestInfo } from '../request/GraphQLRequestInfo'
 
 /**
  * Interface for execution results.

--- a/src/response/GraphQLServerResponse.ts
+++ b/src/response/GraphQLServerResponse.ts
@@ -1,9 +1,16 @@
 export interface GraphQLServerResponse {
     statusCode: number
-    setHeader(
+    // Either header or setHeader should be provided in order to set the response headers.
+    header?(
         name: string,
         value: number | string | ReadonlyArray<string>,
     ): this
-    end(chunk: unknown, callback?: () => void): this
+    setHeader?(
+        name: string,
+        value: number | string | ReadonlyArray<string>,
+    ): this
+    // Either end or send should be provided in order to send the response.
+    end?(chunk: unknown, callback?: () => void): this
+    send?(chunk: unknown, callback?: () => void): this
     removeHeader(name: string): void
 }

--- a/src/response/GraphQLServerResponse.ts
+++ b/src/response/GraphQLServerResponse.ts
@@ -1,10 +1,7 @@
 export interface GraphQLServerResponse {
     statusCode: number
     // Either header or setHeader should be provided in order to set the response headers.
-    header?(
-        name: string,
-        value: number | string | ReadonlyArray<string>,
-    ): this
+    header?(name: string, value: number | string | ReadonlyArray<string>): this
     setHeader?(
         name: string,
         value: number | string | ReadonlyArray<string>,

--- a/src/response/ResponseParameters.ts
+++ b/src/response/ResponseParameters.ts
@@ -1,8 +1,12 @@
-import { ExecutionResult, GraphQLError, GraphQLFormattedError } from 'graphql'
-import { Logger } from '../logger/Logger'
-import { GraphQLServerRequest } from '../request/GraphQLServerRequest'
-import { StandardSchemaV1 } from '../validation/StandardSchemaV1'
-import { GraphQLServerResponse } from './GraphQLServerResponse'
+import {
+    type ExecutionResult,
+    GraphQLError,
+    type GraphQLFormattedError,
+} from 'graphql'
+import type { Logger } from '../logger/Logger'
+import type { GraphQLServerRequest } from '../request/GraphQLServerRequest'
+import type { StandardSchemaV1 } from '../validation/StandardSchemaV1'
+import type { GraphQLServerResponse } from './GraphQLServerResponse'
 
 export interface ResponseParameters {
     readonly context: unknown

--- a/src/response/ResponseParameters.ts
+++ b/src/response/ResponseParameters.ts
@@ -9,16 +9,18 @@ import type { StandardSchemaV1 } from '../validation/StandardSchemaV1'
 import type { GraphQLServerResponse } from './GraphQLServerResponse'
 
 export interface ResponseParameters {
+    // Required fields
     readonly context: unknown
-    readonly customHeaders?: Record<string, string>
-    readonly executionResult?: ExecutionResult
+    readonly executionResult: ExecutionResult
     readonly formatErrorFunction: (error: GraphQLError) => GraphQLFormattedError
     readonly logger: Logger
-    readonly request?: GraphQLServerRequest
     readonly response: GraphQLServerResponse
-    readonly responseEndChunkFunction?: (
+    readonly responseEndChunkFunction: (
         executionResult: ExecutionResult | undefined,
     ) => unknown
-    readonly responseStandardSchema?: StandardSchemaV1
+    readonly responseStandardSchema: StandardSchemaV1
+    // Optional fields
+    readonly customHeaders?: Record<string, string>
+    readonly request?: GraphQLServerRequest
     readonly statusCode?: number
 }

--- a/src/response/ResponseParameters.ts
+++ b/src/response/ResponseParameters.ts
@@ -10,7 +10,7 @@ import type { GraphQLServerResponse } from './GraphQLServerResponse'
 
 export interface ResponseParameters {
     // Required fields
-    readonly context: unknown
+    readonly context: Record<string, unknown>
     readonly executionResult: ExecutionResult
     readonly formatErrorFunction: (error: GraphQLError) => GraphQLFormattedError
     readonly logger: Logger

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "declaration": true,
-        "baseUrl": "."
+        "baseUrl": ".",
+        "verbatimModuleSyntax": true,
+        "erasableSyntaxOnly": true
     },
     "include": ["tsup.config.ts", "src/**/*"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
Prepare graphql-server-base for new graphql-server version 5 release:
- Change context from `unknown` to `Record<string, unknown>`
- Change `LogLevel` and `ContentType` from enum to type
- Add async text function to GraphQLServerRequest
- GraphQLServerResponse
  - Add optional function "`header`"
  - Make `setHeader` optional
  - Add optional function `send`
  - Make `end` optional 
- Adjust `ResponseParameters`
- Typescript: Enable `verbatimModuleSyntax` and `erasableSyntaxOnly`